### PR TITLE
ocaml5: patch camlp-streams missing dependency in requirements

### DIFF
--- a/code/src/netstring/META.in
+++ b/code/src/netstring/META.in
@@ -1,5 +1,5 @@
 version = "@VERSION@"
-requires = "@REGEXP_PROVIDER@ unix netsys @COMPAT_PCRE_PROVIDER@"
+requires = "@REGEXP_PROVIDER@ unix netsys @COMPAT_PCRE_PROVIDER@ camlp-streams"
 description = "Ocamlnet - String processing library"
 
 archive(byte) = 

--- a/opam
+++ b/opam
@@ -49,6 +49,7 @@ remove: [
 
 ]
 depends: [
+  "camlp-streams"
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"


### PR DESCRIPTION
# Fix `Streams` not found issue
encountered this error with the `netstring` library when trying to build with OCaml5 compiler.
```bash
> File "_none_", line 1:
> Error: No implementations provided for the following modules:
>          Stream referenced from /home/me/work/multicore-cont/_opam/lib/netstring/netstring.cmxa(Netdate),
```

Problem was that the `camlp-streams` dependency requirement in the META file was missed. Subsequent users of `ocamlnet` libraries that are referencing `Stream` would need to explicitly add `camlp-streams` to their build rules in order to have the package included in the build. Worse, it had to be linked in the correct order otherwise we would still receive an undefined reference error. 

Adding the rule in `META.in` ensures that the later generated META file specifies the `camlp-streams` dependency. Dune can read this to find out about `netstring` dependencies [(dune integration with findlib)](https://dune.readthedocs.io/en/stable/explanation/ocaml-ecosystem.html#how-dune-integrates-with-the-ecosystem). This then enables dune to construct the link path that implicitly includes `camlp-streams` in the correct order.